### PR TITLE
블루스퀘어 신한카드홀 게시글 create 및 SeatDto수정

### DIFF
--- a/src/main/java/com/example/SEENEMA/domain/seat/SeatController.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/SeatController.java
@@ -38,7 +38,7 @@ public class SeatController {
     private final UserRepository userRepo;
 
     @ApiOperation(value="좌석별 게시물 조회")
-    @GetMapping("/{theaterId}/{x}/{y}/{z}")
+    @GetMapping("/{theaterId}/{z}/{x}/{y}")
     public ResponseEntity getListBySeat(
             @PathVariable("theaterId") Long theaterId,
             @PathVariable("z") int z,
@@ -47,6 +47,7 @@ public class SeatController {
 
         /** 아르코 예술극장 */
         if (theaterId == 37) {
+//            System.out.println(x+" / "+y+" / "+z);
             ArcoSeat seat = arcoRepository.findByXAndYAndZ(x, y, z);
             Long seatId = seat.getSeatId();
             return ResponseEntity.ok(arcoService.getListBySeat(theaterId, seatId));
@@ -89,10 +90,7 @@ public class SeatController {
         }
         /** 블루스퀘어 신한카드홀 */
         else if (theaterId == 12) {
-            //블루스퀘어 seat = 블루스퀘어Repository.findByXAndY(x, y);
-            //Long seatId = seat.getSeatId();
-            //return ResponseEntity.ok(블루스퀘어Service.createViewPost(user.get().getUserId(), theaterId, seatId, viewDto));
-            ShinhanSeat seat =shinhanRepository.findByXAndY(x,y);
+            ShinhanSeat seat =shinhanRepository.findByXAndYAndZ(x, y, z);
             Long seatId = seat.getSeatId();
             return ResponseEntity.ok(shinhanService.createViewPost(user.get().getUserId(), theaterId, seatId, viewDto));
         }

--- a/src/main/java/com/example/SEENEMA/domain/seat/SeatController.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/SeatController.java
@@ -3,6 +3,9 @@ package com.example.SEENEMA.domain.seat;
 import com.example.SEENEMA.domain.post.file.Image;
 import com.example.SEENEMA.domain.post.file.ImageService;
 import com.example.SEENEMA.domain.seat.arcoTheater.ArcoService;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.ShinhanService;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanSeat;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.repository.ShinhanRepository;
 import com.example.SEENEMA.domain.user.domain.User;
 import com.example.SEENEMA.global.jwt.JwtTokenProvider;
 import com.example.SEENEMA.domain.seat.arcoTheater.domain.ArcoSeat;
@@ -28,6 +31,8 @@ import java.util.Optional;
 public class SeatController {
     private final ArcoRepository arcoRepository;
     private final ArcoService arcoService;
+    private final ShinhanRepository shinhanRepository;
+    private final ShinhanService shinhanService;
     private final ImageService imageService;
     private final JwtTokenProvider provider;
     private final UserRepository userRepo;
@@ -82,6 +87,9 @@ public class SeatController {
             //블루스퀘어 seat = 블루스퀘어Repository.findByXAndY(x, y);
             //Long seatId = seat.getSeatId();
             //return ResponseEntity.ok(블루스퀘어Service.createViewPost(user.get().getUserId(), theaterId, seatId, viewDto));
+            ShinhanSeat seat =shinhanRepository.findByXAndY(x,y);
+            Long seatId = seat.getSeatId();
+            return ResponseEntity.ok(shinhanService.createViewPost(user.get().getUserId(), theaterId, seatId, viewDto));
         }
         return ResponseEntity.notFound().build();
     }

--- a/src/main/java/com/example/SEENEMA/domain/seat/SeatDto.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/SeatDto.java
@@ -1,6 +1,7 @@
 package com.example.SEENEMA.domain.seat;
 
 import com.example.SEENEMA.domain.post.file.Image;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanPost;
 import com.example.SEENEMA.domain.user.domain.User;
 import com.example.SEENEMA.domain.seat.arcoTheater.domain.ArcoSeat;
 import com.example.SEENEMA.domain.seat.arcoTheater.domain.ArcoPost;
@@ -8,6 +9,7 @@ import com.example.SEENEMA.domain.theater.domain.Theater;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -15,14 +17,14 @@ import java.util.List;
 @Setter
 public class SeatDto {
 
-/** 게시글 등록을 처리할 Request 클래스 */
+    /** 게시글 등록을 처리할 Request 클래스 */
     @Getter
     @Setter
     public static class addRequest{
         private User user; // 작성자 id
         private Theater theater; // 공연장
         private String play; // 공연
-        private ArcoSeat arcoSeat; // 좌석
+//        private Seat seat; // 좌석
         private String title; // 제목
         private String content; // 내용
         private Integer viewScore;   // 시야 점수
@@ -31,12 +33,33 @@ public class SeatDto {
         private Integer soundScore;  // 음향 점수
         private List<Image> image; // 이미지 url
 
-        public ArcoPost toEntity(){
+        public ArcoPost toArcoPostEntity(){
             return ArcoPost.builder()
                     .user(user)
                     .theater(theater)
                     .play(play)
-                    .arcoSeat(arcoSeat)
+//                    .arcoSeat(seat)
+                    .title(title)
+                    .content(content)
+                    .viewScore(viewScore)
+                    .seatScore(seatScore)
+                    .lightScore(lightScore)
+                    .soundScore(soundScore)
+                    .image(image)
+                    .build();
+        }
+        /*
+        public ShinhanPost toShinhanPostEntity(){
+            return ShinhanPost.builder()
+                    .user.....;
+        }
+        */
+        public ShinhanPost toShinhanPostEntity(){
+            return ShinhanPost.builder()
+                    .user(user)
+                    .theater(theater)
+                    .play(play)
+//                    .shinhanSeat(seat)
                     .title(title)
                     .content(content)
                     .viewScore(viewScore)
@@ -50,6 +73,7 @@ public class SeatDto {
 
     /** 게시글 정보를 리턴할 Response 클래스 */
     @Getter
+    @Setter
     public static class addResponse{
         private Long userId; // 작성자 id
         private String nickName; // 작성자 닉네임
@@ -85,7 +109,25 @@ public class SeatDto {
             this.image = new ArrayList<>(view.getImage());
             this.createdAt = view.getCreatedAt().toString();
             this.editedAt = view.getEditedAt().toString();
-
+        }
+        //public addResponse(ShinhanPost view){}
+        public addResponse(ShinhanPost view){
+            this.userId = view.getUser().getUserId();
+            this.nickName = view.getUser().getNickname();
+            this.theaterName = view.getTheater().getTheaterName();
+            this.play = view.getPlay();
+            this.seatName = view.getShinhanSeat().getSeatNumber();
+            this.title = view.getTitle();
+            this.content = view.getContent();
+            this.viewScore = view.getViewScore();
+            this.seatScore = view.getSeatScore();
+            this.lightScore = view.getLightScore();
+            this.soundScore = view.getSoundScore();
+            this.heartedYN = Boolean.FALSE;
+            this.heartCount = view.getHeartCount();
+            this.image = new ArrayList<>(view.getImage());
+            this.createdAt = view.getCreatedAt().toString();
+            this.editedAt = view.getEditedAt().toString();
         }
     }
 
@@ -105,6 +147,7 @@ public class SeatDto {
         private List<Image> image;
         private Long heartCount;       //좋아요 갯수
         private Boolean heartedYN;      // 로그인한 사용자의 좋아요 여부
+        private LocalDateTime createAt;
 
         public detailResponse(ArcoPost view){
             this.viewNo = view.getViewNo();
@@ -119,8 +162,36 @@ public class SeatDto {
             this.image = view.getImage();
             this.heartedYN = Boolean.FALSE;
             this.heartCount = view.getHeartCount();
+            this.createAt = view.getCreatedAt();
+        }
+        //public detailResponse(ShinhanPost view){}
+        public detailResponse(ShinhanPost view){
+            this.viewNo = view.getViewNo();
+            this.nickName = view.getUser().getNickname();
+            this.title = view.getTitle();
+            this.content = view.getContent();
+            this.seatName = view.getShinhanSeat().getSeatNumber();
+            this.viewScore = view.getViewScore();
+            this.seatScore = view.getSeatScore();
+            this.lightScore = view.getLightScore();
+            this.soundScore = view.getSoundScore();
+            this.image = view.getImage();
+            this.heartedYN = Boolean.FALSE;
+            this.heartCount = view.getHeartCount();
         }
     }
+    /** 게시글 목록(seatViewList의 List)과 게시글들의 점수 평균, postedYN(게시글 유무)를 리턴할 Response 클래스*/
+    @Getter
+    @Setter
+    public static class postList{
+        private Integer average;
+        private Boolean postedYN;
+        private List<seatViewList> postingList = new ArrayList<>();
+        public postList(List<seatViewList> list){
+            this.postingList = list;
+        }
+    }
+
 
     /** 게시글 목록을 리턴할 Response 클래스 */
     @Getter
@@ -130,7 +201,7 @@ public class SeatDto {
         private String title;
         private String createdAt;
         private Long heartCount;
-        private Integer viewScore;   // 시야 점수
+        private Integer average;    //평점
 
         public seatViewList(ArcoPost view){
             this.viewNo = view.getViewNo();
@@ -138,9 +209,18 @@ public class SeatDto {
             this.title = view.getTitle();
             this.createdAt = view.getCreatedAt().toString();
             this.heartCount = view.getHeartCount();
-            this.viewScore = view.getViewScore();
+//            this.viewScore = view.getViewScore();
+            this.average = (Integer) (view.getViewScore()+view.getViewScore()+view.getLightScore()+view.getSoundScore())/4;
         }
-
+        //public seatViewList(ShinhanPost view){}
+        public seatViewList(ShinhanPost view){
+            this.viewNo = view.getViewNo();
+            this.nickName = view.getUser().getNickname();
+            this.title = view.getTitle();
+            this.createdAt = view.getCreatedAt().toString();
+            this.heartCount = view.getHeartCount();
+//            this.viewScore = view.getViewScore();
+        }
         @Override
         public int compareTo(seatViewList listDTO) {
             if(listDTO.getViewNo() < viewNo) return 1;

--- a/src/main/java/com/example/SEENEMA/domain/seat/SeatDto.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/SeatDto.java
@@ -9,6 +9,7 @@ import com.example.SEENEMA.domain.theater.domain.Theater;
 import lombok.Getter;
 import lombok.Setter;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -146,6 +147,7 @@ public class SeatDto {
         private List<Image> image;
         private Long heartCount;       //좋아요 갯수
         private Boolean heartedYN;      // 로그인한 사용자의 좋아요 여부
+        private LocalDateTime createAt;
 
         public detailResponse(ArcoPost view){
             this.viewNo = view.getViewNo();
@@ -160,9 +162,36 @@ public class SeatDto {
             this.image = view.getImage();
             this.heartedYN = Boolean.FALSE;
             this.heartCount = view.getHeartCount();
+            this.createAt = view.getCreatedAt();
         }
         //public detailResponse(ShinhanPost view){}
+        public detailResponse(ShinhanPost view){
+            this.viewNo = view.getViewNo();
+            this.nickName = view.getUser().getNickname();
+            this.title = view.getTitle();
+            this.content = view.getContent();
+            this.seatName = view.getShinhanSeat().getSeatNumber();
+            this.viewScore = view.getViewScore();
+            this.seatScore = view.getSeatScore();
+            this.lightScore = view.getLightScore();
+            this.soundScore = view.getSoundScore();
+            this.image = view.getImage();
+            this.heartedYN = Boolean.FALSE;
+            this.heartCount = view.getHeartCount();
+        }
     }
+    /** 게시글 목록(seatViewList의 List)과 게시글들의 점수 평균, postedYN(게시글 유무)를 리턴할 Response 클래스*/
+    @Getter
+    @Setter
+    public static class postList{
+        private Integer average;
+        private Boolean postedYN;
+        private List<seatViewList> postingList = new ArrayList<>();
+        public postList(List<seatViewList> list){
+            this.postingList = list;
+        }
+    }
+
 
     /** 게시글 목록을 리턴할 Response 클래스 */
     @Getter
@@ -172,7 +201,7 @@ public class SeatDto {
         private String title;
         private String createdAt;
         private Long heartCount;
-        private Integer viewScore;   // 시야 점수
+        private Integer average;    //평점
 
         public seatViewList(ArcoPost view){
             this.viewNo = view.getViewNo();
@@ -180,10 +209,18 @@ public class SeatDto {
             this.title = view.getTitle();
             this.createdAt = view.getCreatedAt().toString();
             this.heartCount = view.getHeartCount();
-            this.viewScore = view.getViewScore();
+//            this.viewScore = view.getViewScore();
+            this.average = (Integer) (view.getViewScore()+view.getViewScore()+view.getLightScore()+view.getSoundScore())/4;
         }
         //public seatViewList(ShinhanPost view){}
-
+        public seatViewList(ShinhanPost view){
+            this.viewNo = view.getViewNo();
+            this.nickName = view.getUser().getNickname();
+            this.title = view.getTitle();
+            this.createdAt = view.getCreatedAt().toString();
+            this.heartCount = view.getHeartCount();
+//            this.viewScore = view.getViewScore();
+        }
         @Override
         public int compareTo(seatViewList listDTO) {
             if(listDTO.getViewNo() < viewNo) return 1;

--- a/src/main/java/com/example/SEENEMA/domain/seat/SeatDto.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/SeatDto.java
@@ -1,6 +1,7 @@
 package com.example.SEENEMA.domain.seat;
 
 import com.example.SEENEMA.domain.post.file.Image;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanPost;
 import com.example.SEENEMA.domain.user.domain.User;
 import com.example.SEENEMA.domain.seat.arcoTheater.domain.ArcoSeat;
 import com.example.SEENEMA.domain.seat.arcoTheater.domain.ArcoPost;
@@ -22,7 +23,7 @@ public class SeatDto {
         private User user; // 작성자 id
         private Theater theater; // 공연장
         private String play; // 공연
-        private ArcoSeat arcoSeat; // 좌석
+//        private Seat seat; // 좌석
         private String title; // 제목
         private String content; // 내용
         private Integer viewScore;   // 시야 점수
@@ -31,12 +32,33 @@ public class SeatDto {
         private Integer soundScore;  // 음향 점수
         private List<Image> image; // 이미지 url
 
-        public ArcoPost toEntity(){
+        public ArcoPost toArcoPostEntity(){
             return ArcoPost.builder()
                     .user(user)
                     .theater(theater)
                     .play(play)
-                    .arcoSeat(arcoSeat)
+//                    .arcoSeat(seat)
+                    .title(title)
+                    .content(content)
+                    .viewScore(viewScore)
+                    .seatScore(seatScore)
+                    .lightScore(lightScore)
+                    .soundScore(soundScore)
+                    .image(image)
+                    .build();
+        }
+        /*
+        public ShinhanPost toShinhanPostEntity(){
+            return ShinhanPost.builder()
+                    .user.....;
+        }
+        */
+        public ShinhanPost toShinhanPostEntity(){
+            return ShinhanPost.builder()
+                    .user(user)
+                    .theater(theater)
+                    .play(play)
+//                    .shinhanSeat(seat)
                     .title(title)
                     .content(content)
                     .viewScore(viewScore)
@@ -50,6 +72,7 @@ public class SeatDto {
 
     /** 게시글 정보를 리턴할 Response 클래스 */
     @Getter
+    @Setter
     public static class addResponse{
         private Long userId; // 작성자 id
         private String nickName; // 작성자 닉네임
@@ -85,7 +108,25 @@ public class SeatDto {
             this.image = new ArrayList<>(view.getImage());
             this.createdAt = view.getCreatedAt().toString();
             this.editedAt = view.getEditedAt().toString();
-
+        }
+        //public addResponse(ShinhanPost view){}
+        public addResponse(ShinhanPost view){
+            this.userId = view.getUser().getUserId();
+            this.nickName = view.getUser().getNickname();
+            this.theaterName = view.getTheater().getTheaterName();
+            this.play = view.getPlay();
+            this.seatName = view.getShinhanSeat().getSeatNumber();
+            this.title = view.getTitle();
+            this.content = view.getContent();
+            this.viewScore = view.getViewScore();
+            this.seatScore = view.getSeatScore();
+            this.lightScore = view.getLightScore();
+            this.soundScore = view.getSoundScore();
+            this.heartedYN = Boolean.FALSE;
+            this.heartCount = view.getHeartCount();
+            this.image = new ArrayList<>(view.getImage());
+            this.createdAt = view.getCreatedAt().toString();
+            this.editedAt = view.getEditedAt().toString();
         }
     }
 
@@ -120,6 +161,7 @@ public class SeatDto {
             this.heartedYN = Boolean.FALSE;
             this.heartCount = view.getHeartCount();
         }
+        //public detailResponse(ShinhanPost view){}
     }
 
     /** 게시글 목록을 리턴할 Response 클래스 */
@@ -140,6 +182,7 @@ public class SeatDto {
             this.heartCount = view.getHeartCount();
             this.viewScore = view.getViewScore();
         }
+        //public seatViewList(ShinhanPost view){}
 
         @Override
         public int compareTo(seatViewList listDTO) {

--- a/src/main/java/com/example/SEENEMA/domain/seat/arcoTheater/ArcoService.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/arcoTheater/ArcoService.java
@@ -94,12 +94,27 @@ public class ArcoService {
         return readViewPost(theaterId, seatId, viewNo);
     }
 
-    public List<SeatDto.seatViewList> getListBySeat(Long theaterId, Long seatId){
-        List<SeatDto.seatViewList> response = arcoPostRepository.findByTheater_TheaterIdAndArcoSeat_SeatId(theaterId,seatId).stream()
+    public SeatDto.postList getListBySeat(Long theaterId, Long seatId){
+        List<SeatDto.seatViewList> seatViewLists = arcoPostRepository.findByTheater_TheaterIdAndArcoSeat_SeatId(theaterId,seatId).stream()
                 .map(SeatDto.seatViewList::new)
                 .collect(Collectors.toList());
-        Collections.sort(response, Collections.reverseOrder());
-        return response;
+        Collections.sort(seatViewLists, Collections.reverseOrder());
+        SeatDto.postList response = new SeatDto.postList(seatViewLists);
+        if(seatViewLists.isEmpty()) {
+            response.setPostedYN(Boolean.FALSE);
+            response.setAverage(0);
+            return response;
+        }
+        else {
+            response.setPostedYN(Boolean.TRUE);
+            int avr = 0;
+            for(SeatDto.seatViewList s : seatViewLists){
+                avr += s.getAverage();
+            }
+            avr/=seatViewLists.size();
+            response.setAverage(avr);
+            return response;
+        }
     }
 
     private ArcoPost getSeatViewPost(Long theaterId, Long seatId, Long viewNo) {

--- a/src/main/java/com/example/SEENEMA/domain/seat/arcoTheater/ArcoService.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/arcoTheater/ArcoService.java
@@ -9,7 +9,6 @@ import com.example.SEENEMA.domain.post.file.ImageRepository;
 import com.example.SEENEMA.domain.seat.arcoTheater.domain.ArcoSeat;
 import com.example.SEENEMA.domain.seat.arcoTheater.domain.ArcoPost;
 import com.example.SEENEMA.domain.seat.arcoTheater.repository.ArcoRepository;
-import com.example.SEENEMA.domain.post.view.repository.ViewPostHeartRepository;
 import com.example.SEENEMA.domain.theater.domain.Theater;
 import com.example.SEENEMA.domain.theater.repository.TheaterRepository;
 import com.example.SEENEMA.domain.user.domain.User;
@@ -33,7 +32,6 @@ public class ArcoService {
     private final UserRepository userRepository;
     private final TheaterRepository theaterRepository;
     private final ImageRepository imageRepository;
-    private final ViewPostHeartRepository heartRepository;
     private final ArcoHeartRepository arcoHeartRepository;
 
     public static String convertToSeatNumber(int x, int y, int z) {
@@ -53,10 +51,11 @@ public class ArcoService {
 
         requestDto.setUser(user);
         requestDto.setTheater(theater);
-        requestDto.setArcoSeat(arcoSeat);
+//        requestDto.setArcoSeat(arcoSeat);
         requestDto.setImage(images);
 
-        ArcoPost view = requestDto.toEntity();
+        ArcoPost view = requestDto.toArcoPostEntity();
+        view.setArcoSeat(arcoSeat); // requestDto에 Seat 정보 지워서 설정 따로 필요
 
         // ViewPost 엔티티에 저장된 Image 엔티티들을 영속화
         List<Image> persistedImages = new ArrayList<>();
@@ -93,12 +92,27 @@ public class ArcoService {
         return readViewPost(theaterId, seatId, viewNo);
     }
 
-    public List<SeatDto.seatViewList> getListBySeat(Long theaterId, Long seatId){
-        List<SeatDto.seatViewList> response = arcoPostRepository.findByTheater_TheaterIdAndArcoSeat_SeatId(theaterId,seatId).stream()
+    public SeatDto.postList getListBySeat(Long theaterId, Long seatId){
+        List<SeatDto.seatViewList> seatViewLists = arcoPostRepository.findByTheater_TheaterIdAndArcoSeat_SeatId(theaterId,seatId).stream()
                 .map(SeatDto.seatViewList::new)
                 .collect(Collectors.toList());
-        Collections.sort(response, Collections.reverseOrder());
-        return response;
+        Collections.sort(seatViewLists, Collections.reverseOrder());
+        SeatDto.postList response = new SeatDto.postList(seatViewLists);
+        if(seatViewLists.isEmpty()) {
+            response.setPostedYN(Boolean.FALSE);
+            response.setAverage(0);
+            return response;
+        }
+        else {
+            response.setPostedYN(Boolean.TRUE);
+            int avr = 0;
+            for(SeatDto.seatViewList s : seatViewLists){
+                avr += s.getAverage();
+            }
+            avr/=seatViewLists.size();
+            response.setAverage(avr);
+            return response;
+        }
     }
 
     private ArcoPost getSeatViewPost(Long theaterId, Long seatId, Long viewNo) {

--- a/src/main/java/com/example/SEENEMA/domain/seat/arcoTheater/ArcoService.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/arcoTheater/ArcoService.java
@@ -52,10 +52,11 @@ public class ArcoService {
 
         requestDto.setUser(user);
         requestDto.setTheater(theater);
-        requestDto.setArcoSeat(arcoSeat);
+//        requestDto.setArcoSeat(arcoSeat);
         requestDto.setImage(images);
 
-        ArcoPost view = requestDto.toEntity();
+        ArcoPost view = requestDto.toArcoPostEntity();
+        view.setArcoSeat(arcoSeat); // requestDto에 Seat 정보 지워서 설정 따로 필요
 
         // ViewPost 엔티티에 저장된 Image 엔티티들을 영속화
         List<Image> persistedImages = new ArrayList<>();

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/ShinhanService.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/ShinhanService.java
@@ -1,0 +1,78 @@
+package com.example.SEENEMA.domain.seat.blueSquareShinhan;
+
+import com.example.SEENEMA.domain.post.file.Image;
+import com.example.SEENEMA.domain.post.file.ImageRepository;
+import com.example.SEENEMA.domain.seat.SeatDto;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanPost;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanSeat;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.repository.ShinhanPostRepository;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.repository.ShinhanRepository;
+import com.example.SEENEMA.domain.theater.domain.Theater;
+import com.example.SEENEMA.domain.theater.repository.TheaterRepository;
+import com.example.SEENEMA.domain.user.domain.User;
+import com.example.SEENEMA.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+public class ShinhanService {
+    private final ShinhanRepository shinhanRepository;
+    private final ShinhanPostRepository shinhanPostRepository;
+    private final UserRepository userRepository;
+    private final TheaterRepository theaterRepository;
+    private final ImageRepository imageRepository;
+    public static String convertToSeatNumber(Integer x, Integer y) {
+        String column = String.valueOf(x);  // 열은 x 좌표 그대로 사용
+        String number = String.valueOf(y);  // 번호는 y 좌표 그대로 사용
+
+        return column + "열 " + number + "번";
+    }
+    public SeatDto.addResponse createViewPost(Long userId, Long theaterId, Long seatId, SeatDto.addRequest request){
+        User user = getUser(userId);
+        Theater theater = getTheater(theaterId);
+        ShinhanSeat seat = getSeat(seatId).get();
+        List<Image> images = getImage(request.getImage());
+
+        request.setUser(user);
+        request.setTheater(theater);
+//        request.setShinhanSeat(seat);
+        request.setImage(images);
+
+        ShinhanPost view = request.toShinhanPostEntity();
+        view.setShinhanSeat(seat);
+
+        List<Image> persistedImages = new ArrayList<>();
+        for(Image image : images){
+            persistedImages.add(imageRepository.save(image));
+        }
+        view.setImage(persistedImages);
+        return new SeatDto.addResponse(shinhanPostRepository.save(view));
+    }
+    private User getUser(Long userId){
+        return userRepository.findById(userId).orElseThrow();
+    }
+    private Theater getTheater(Long theaterId){
+        return theaterRepository.findById(theaterId).orElseThrow();
+    }
+    private List<Image> getImage(List<Image> images){
+        List<Image> tmp = imageRepository.findAll();
+        for (Image a : tmp){
+            for(Image i : images){
+                if(a.getImgUrl().equals(i.getImgUrl()))
+                    i.setImgUrl(a.getImgUrl());
+            }
+        }
+        return images;
+    }
+    private Optional<ShinhanSeat> getSeat(Long seatId){
+        return shinhanRepository.findById(seatId);
+    }
+
+}

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/ShinhanService.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/ShinhanService.java
@@ -28,11 +28,12 @@ public class ShinhanService {
     private final UserRepository userRepository;
     private final TheaterRepository theaterRepository;
     private final ImageRepository imageRepository;
-    public static String convertToSeatNumber(Integer x, Integer y) {
+    public static String convertToSeatNumber(int x, int y, int z) {
         String column = String.valueOf(x);  // 열은 x 좌표 그대로 사용
         String number = String.valueOf(y);  // 번호는 y 좌표 그대로 사용
+        String floor = String.valueOf(z); // 층은 z 좌표 그대로 사용
 
-        return column + "열 " + number + "번";
+        return floor + "층 " + column + "열 " + number + "번";
     }
     public SeatDto.addResponse createViewPost(Long userId, Long theaterId, Long seatId, SeatDto.addRequest request){
         User user = getUser(userId);

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/domain/ShinhanHeart.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/domain/ShinhanHeart.java
@@ -1,0 +1,33 @@
+package com.example.SEENEMA.domain.seat.blueSquareShinhan.domain;
+
+import com.example.SEENEMA.domain.user.domain.User;
+import lombok.*;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+
+@Getter
+@Setter
+@Table(name = "shinhan_heart")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class ShinhanHeart {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id")
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "view_no")
+    private ShinhanPost viewPost;
+
+    @Builder
+    public ShinhanHeart(User user, ShinhanPost viewPost){
+        this.user = user;
+        this.viewPost = viewPost;
+    }
+}

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/domain/ShinhanPost.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/domain/ShinhanPost.java
@@ -1,0 +1,82 @@
+package com.example.SEENEMA.domain.seat.blueSquareShinhan.domain;
+
+import com.example.SEENEMA.domain.post.file.Image;
+import com.example.SEENEMA.domain.theater.domain.Theater;
+import com.example.SEENEMA.domain.user.domain.User;
+import lombok.*;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@Table(name = "shinhan_post")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+public class ShinhanPost {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long viewNo; // 게시글 no
+
+    @ManyToOne
+    @JoinColumn(name="user_id")
+    private User user; // 작성자 id
+
+    @ManyToOne
+    @JoinColumn(name="theater_id")
+    private Theater theater; // 공연장
+
+    @Column
+    private String play; // 공연
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_id")
+    private ShinhanSeat shinhanSeat;
+    @Column
+    private String title;
+    private String content; // 내용
+    @Column
+    private Integer viewScore;   // 시야 점수
+    @Column
+    private Integer seatScore;   // 좌석 점수
+    @Column
+    private Integer lightScore;  // 조명 점수
+    @Column
+    private Integer soundScore;  // 음향 점수
+    @OneToMany(cascade = CascadeType.ALL)
+    private List<Image> image;
+
+    @CreatedDate // 생성일 자동화
+    @Column(updatable = false)
+    private LocalDateTime createdAt; // 작성 일시
+
+    @LastModifiedDate // 수정일 자동화
+    @Column
+    private LocalDateTime editedAt; // 최종 수정 일시
+    @Column
+    private Long heartCount;
+
+    @Builder
+    public ShinhanPost(User user, Theater theater, String play, ShinhanSeat shinhanSeat, String title, String content,
+                       Integer viewScore, Integer seatScore, Integer lightScore, Integer soundScore,
+                       List<Image> image, LocalDateTime createdAt){
+        this.user = user;
+        this.theater = theater;
+        this.play = play;
+        this.shinhanSeat = shinhanSeat;
+        this.title = title;
+        this.content = content;
+        this.viewScore = viewScore;
+        this.seatScore = seatScore;
+        this.lightScore = lightScore;
+        this.soundScore = soundScore;
+        this.image = image;
+        this.createdAt = createdAt;
+        this.heartCount = 0L;
+    }
+}

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/domain/ShinhanSeat.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/domain/ShinhanSeat.java
@@ -1,0 +1,31 @@
+package com.example.SEENEMA.domain.seat.blueSquareShinhan.domain;
+
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.ShinhanService;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Entity
+@Table(name = "blue_square_shinhan")
+public class ShinhanSeat {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long seatId;
+    private Integer x;
+    private Integer y;
+
+    @OneToMany(mappedBy = "shinhanSeat", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<ShinhanPost> shinhanPosts = new ArrayList<>();
+
+    public String getSeatNumber(){
+        return ShinhanService.convertToSeatNumber(x,y);
+    }
+}

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/domain/ShinhanSeat.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/domain/ShinhanSeat.java
@@ -21,11 +21,12 @@ public class ShinhanSeat {
     private Long seatId;
     private Integer x;
     private Integer y;
+    private int z;
 
     @OneToMany(mappedBy = "shinhanSeat", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ShinhanPost> shinhanPosts = new ArrayList<>();
 
     public String getSeatNumber(){
-        return ShinhanService.convertToSeatNumber(x,y);
+        return ShinhanService.convertToSeatNumber(x, y, z);
     }
 }

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/repository/ShinhanHeartRepository.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/repository/ShinhanHeartRepository.java
@@ -1,0 +1,18 @@
+package com.example.SEENEMA.domain.seat.blueSquareShinhan.repository;
+
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanHeart;
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanPost;
+import com.example.SEENEMA.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface ShinhanHeartRepository extends JpaRepository<ShinhanHeart, Long> {
+    @Query
+    List<ShinhanHeart> findByViewPost(ShinhanPost shinhanPost);
+    @Query
+    ShinhanPost findByUserAndViewPost(User user,ShinhanPost shinhanPost);
+    @Query
+    List<ShinhanHeart> findByUser(User user);
+}

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/repository/ShinhanPostRepository.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/repository/ShinhanPostRepository.java
@@ -1,0 +1,14 @@
+package com.example.SEENEMA.domain.seat.blueSquareShinhan.repository;
+
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanPost;
+import com.example.SEENEMA.domain.user.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface ShinhanPostRepository extends JpaRepository<ShinhanPost, Long> {
+    List<ShinhanPost> findByTheater_TheaterId(Long theaterId);
+    List<ShinhanPost> findByTheater_TheaterIdAndTitleContaining(Long theaterId, String seatName);
+    ShinhanPost findByTheater_TheaterIdAndViewNo(Long theaterId, Long viewNo);
+    List<ShinhanPost> findByUser(User user);
+}

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/repository/ShinhanRepository.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/repository/ShinhanRepository.java
@@ -1,0 +1,10 @@
+package com.example.SEENEMA.domain.seat.blueSquareShinhan.repository;
+
+import com.example.SEENEMA.domain.seat.blueSquareShinhan.domain.ShinhanSeat;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+public interface ShinhanRepository extends JpaRepository<ShinhanSeat, Long> {
+    @Query
+    ShinhanSeat findByXAndY(Integer x, Integer y);
+}

--- a/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/repository/ShinhanRepository.java
+++ b/src/main/java/com/example/SEENEMA/domain/seat/blueSquareShinhan/repository/ShinhanRepository.java
@@ -6,5 +6,5 @@ import org.springframework.data.jpa.repository.Query;
 
 public interface ShinhanRepository extends JpaRepository<ShinhanSeat, Long> {
     @Query
-    ShinhanSeat findByXAndY(Integer x, Integer y);
+    ShinhanSeat findByXAndYAndZ(Integer x, Integer y, Integer z);
 }


### PR DESCRIPTION
## 📢 작업 내용
- #58
<br>

## 🔍 변경사항
- 블루스퀘어 신한카드홀 CREATE 만 가능
- 
- SeatDto 수정사항
- 좌석별 게시글 상세화면에 createAt 추가
- 좌석별 게시글 목록에 게시글 유무 YN 추가
- 좌석별 게시글 목록에서, 게시글이 하나 이상일때, 전체 평균 점수 추가
- 좌석별 게시글 목록에 각 게시글 평점을 viewScore만 나오는 거에서 평균 각 게시글의 별점(4가지)의 평균으로 수정
